### PR TITLE
Fix spr.d.ts being incompatible w/ certain instances

### DIFF
--- a/spr.d.ts
+++ b/spr.d.ts
@@ -15,8 +15,8 @@ declare namespace spr {
 		| Color3;
 
 	export type Properties<T extends Instance> = ExtractMembers<WritableInstanceProperties<T>, spr.Tweenable> &
-		(T extends PVInstance ? { Pivot: CFrame } : never) &
-		(T extends Model ? { Scale: number } : never);
+		(T extends PVInstance ? { Pivot: CFrame } : {}) &
+		(T extends Model ? { Scale: number } : {});
 }
 
 interface spr {


### PR DESCRIPTION
When attempting to use the library to spring camera FOV the outputted type from the generic would become a `never`. This PR aims to resolve that issue, by editing the type to be an empty map instead.